### PR TITLE
fix: point appVersion to real mal-sync image tag v1.0.5

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mimir-sync
 description: A Helm chart for syncing Mimir and Loki configurations including alertmanager config and rules
 type: application
-version: 3.0.2
-appVersion: "3.0.0"
+version: 3.0.3
+appVersion: "v1.0.5"
 
 # A list of keywords as strings
 keywords:

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,6 +1,6 @@
 # mimir-sync
 
-![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
+![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.5](https://img.shields.io/badge/AppVersion-v1.0.5-informational?style=flat-square)
 
 A Helm chart for syncing Mimir and Loki configurations including alertmanager config and rules
 


### PR DESCRIPTION
## Problem

Artifact Hub scan failed:
```
error scanning image ghcr.io/antnsn/mal-sync:3.0.0: image not found (package mimir-sync:3.0.0)
```

`appVersion: "3.0.0"` was never published to `ghcr.io/antnsn/mal-sync`. Real tags are `v1.0.x` (latest `v1.0.5`).

Since the sync-job templates render the image as:
```
{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
```
default-tag deploys hit **ImagePullBackOff**, and Artifact Hub's scanner errored.

## Fix

- `appVersion` `3.0.0` → `v1.0.5` (latest real ghcr tag, verified `200`).
- Chart `version` `3.0.2` → `3.0.3`.
- Regenerated README badge via helm-docs.

## Validation

- `helm lint chart/` ✓
- Rendered image now `ghcr.io/antnsn/mal-sync:v1.0.5` (ghcr manifest `200`) ✓
- helm-docs no drift ✓
- `/codex:review` clean

After merge, `release.yaml` tags `v3.0.3` and republishes; Artifact Hub re-scans `v1.0.5` and the error clears.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>