### PR TITLE
feat: DRY sync-job templates, harden pods, and streamline CI

### DIFF
--- a/.github/actions/setup-helm-docs/action.yml
+++ b/.github/actions/setup-helm-docs/action.yml
@@ -1,0 +1,24 @@
+name: Setup helm-docs
+description: Install a pinned helm-docs binary onto the runner.
+
+inputs:
+  version:
+    description: helm-docs release version, without the leading "v".
+    required: false
+    default: "1.14.2"
+
+runs:
+  using: composite
+  steps:
+    - name: Install helm-docs
+      shell: bash
+      env:
+        HELM_DOCS_VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        curl -sSL -o /tmp/helm-docs.tgz \
+          "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
+        tar -xzf /tmp/helm-docs.tgz -C /tmp helm-docs
+        sudo install -m 0755 /tmp/helm-docs /usr/local/bin/helm-docs
+        # No version probe: helm-docs 1.14.2 has no --version flag; the tar
+        # extraction above already fails loudly if the binary is missing.

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -6,6 +6,10 @@ on:
       - "chart/**"
       - ".github/workflows/*.y*ml"
 
+concurrency:
+  group: lint-test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: lint, install
@@ -26,15 +30,7 @@ jobs:
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
 
       - name: Install helm-docs
-        run: |
-          set -euo pipefail
-          HELM_DOCS_VERSION=1.14.2
-          curl -sSL -o /tmp/helm-docs.tgz \
-            "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
-          tar -xzf /tmp/helm-docs.tgz -C /tmp helm-docs
-          sudo install -m 0755 /tmp/helm-docs /usr/local/bin/helm-docs
-          # No version probe: helm-docs 1.14.2 has no --version flag; tar above
-          # already fails loudly if the binary is missing.
+        uses: ./.github/actions/setup-helm-docs
 
       - name: Run helm-docs check
         working-directory: chart

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,15 +56,7 @@ jobs:
           CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install helm-docs
-        run: |
-          set -euo pipefail
-          HELM_DOCS_VERSION=1.14.2
-          curl -sSL -o /tmp/helm-docs.tgz \
-            "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
-          tar -xzf /tmp/helm-docs.tgz -C /tmp helm-docs
-          sudo install -m 0755 /tmp/helm-docs /usr/local/bin/helm-docs
-          # No version probe: helm-docs 1.14.2 has no --version flag; tar above
-          # already fails loudly if the binary is missing.
+        uses: ./.github/actions/setup-helm-docs
 
       - name: Update Chart README
         working-directory: chart

--- a/.github/workflows/superlinter.yaml
+++ b/.github/workflows/superlinter.yaml
@@ -6,6 +6,10 @@ permissions: {}
 
 on: pull_request
 
+concurrency:
+  group: superlinter-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   super-linter:
     name: Lint Code Base
@@ -50,15 +54,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install helm-docs
-        run: |
-          set -euo pipefail
-          HELM_DOCS_VERSION=1.14.2
-          curl -sSL -o /tmp/helm-docs.tgz \
-            "https://github.com/norwoodj/helm-docs/releases/download/v${HELM_DOCS_VERSION}/helm-docs_${HELM_DOCS_VERSION}_Linux_x86_64.tar.gz"
-          tar -xzf /tmp/helm-docs.tgz -C /tmp helm-docs
-          sudo install -m 0755 /tmp/helm-docs /usr/local/bin/helm-docs
-          # No version probe: helm-docs 1.14.2 has no --version flag; tar above
-          # already fails loudly if the binary is missing.
+        uses: ./.github/actions/setup-helm-docs
       - name: Run helm-docs
         run: |
           helm-docs

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mimir-sync
 description: A Helm chart for syncing Mimir and Loki configurations including alertmanager config and rules
 type: application
-version: 3.0.3
+version: 3.1.0
 appVersion: "v1.0.5"
 
 # A list of keywords as strings

--- a/chart/README.md
+++ b/chart/README.md
@@ -1,6 +1,6 @@
 # mimir-sync
 
-![Version: 3.0.3](https://img.shields.io/badge/Version-3.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.5](https://img.shields.io/badge/AppVersion-v1.0.5-informational?style=flat-square)
+![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.5](https://img.shields.io/badge/AppVersion-v1.0.5-informational?style=flat-square)
 
 A Helm chart for syncing Mimir and Loki configurations including alertmanager config and rules
 
@@ -20,6 +20,7 @@ A Helm chart for syncing Mimir and Loki configurations including alertmanager co
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| alertmanager.activeDeadlineSeconds | string | `""` | Job .spec.activeDeadlineSeconds. Caps the wall-clock runtime of a sync attempt so a hung mimirtool/lokitool (e.g. unreachable backend) cannot run forever. Empty = unset. |
 | alertmanager.affinity | object | `{}` | Affinity rules for the alertmanager sync Job. |
 | alertmanager.backoffLimit | int | `2` | Job .spec.backoffLimit. |
 | alertmanager.config.existingName | string | `""` | Use an existing ConfigMap/Secret instead of letting the chart create one. |
@@ -51,6 +52,7 @@ A Helm chart for syncing Mimir and Loki configurations including alertmanager co
 | loki.password | string | `""` | Optional Loki basic-auth password. Prefer existingSecret in production. |
 | loki.tenantId | string | `"anonymous"` | Loki tenant ID (X-Scope-OrgID). |
 | loki.user | string | `""` | Optional Loki basic-auth username. |
+| lokiRules.activeDeadlineSeconds | string | `""` | Job .spec.activeDeadlineSeconds. Caps the wall-clock runtime of a sync attempt so a hung mimirtool/lokitool (e.g. unreachable backend) cannot run forever. Empty = unset. |
 | lokiRules.affinity | object | `{}` | Affinity rules for the loki-rules sync Job. |
 | lokiRules.backoffLimit | int | `2` | Job .spec.backoffLimit. |
 | lokiRules.config.existingName | string | `""` | Use an existing ConfigMap/Secret instead of letting the chart create one. |
@@ -77,6 +79,7 @@ A Helm chart for syncing Mimir and Loki configurations including alertmanager co
 | nameOverride | string | `""` | Override the chart name (defaults to .Chart.Name). |
 | namespaces.mimir | string | `"default"` | Mimir rules namespace (--rules.namespace for mimir-rules). |
 | rbac.create | bool | `true` | Create namespace-scoped Role and RoleBinding granting read access to the ConfigMaps/Secrets this chart manages. Most users can leave this enabled. |
+| rules.activeDeadlineSeconds | string | `""` | Job .spec.activeDeadlineSeconds. Caps the wall-clock runtime of a sync attempt so a hung mimirtool/lokitool (e.g. unreachable backend) cannot run forever. Empty = unset. |
 | rules.affinity | object | `{}` | Affinity rules for the rules sync Job. |
 | rules.backoffLimit | int | `2` | Job .spec.backoffLimit. |
 | rules.config.existingName | string | `""` | Use an existing ConfigMap/Secret instead of letting the chart create one. |

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -64,6 +64,74 @@ ServiceAccount name.
 {{- end -}}
 
 {{/*
+Container image reference (repository:tag), tag defaulting to the chart appVersion.
+*/}}
+{{- define "mimir-sync.image" -}}
+{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+{{- end -}}
+
+{{/*
+Shared pod scheduling block for the sync Jobs. Call with a dict:
+  (dict "ctx" . "feature" .Values.<feature>)
+Include with `nindent 6` (the pod spec indent). securityContext is chart-global;
+the remaining knobs are per-feature.
+*/}}
+{{- define "mimir-sync.podScheduling" -}}
+serviceAccountName: {{ include "mimir-sync.serviceAccountName" .ctx }}
+restartPolicy: OnFailure
+automountServiceAccountToken: false
+{{- with .ctx.Values.securityContext }}
+securityContext:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .feature.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .feature.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .feature.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .feature.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .feature.topologySpreadConstraints }}
+topologySpreadConstraints:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Mimir connection env vars shared by the alertmanager and rules Jobs.
+Include with `nindent 12` (the container env list indent).
+*/}}
+{{- define "mimir-sync.mimirEnv" -}}
+- name: MIMIR_ADDRESS
+  value: {{ .Values.mimir.address | quote }}
+- name: MIMIR_TENANT_ID
+  value: {{ .Values.mimir.tenantId | quote }}
+{{- if .Values.mimir.user }}
+- name: MIMIR_USER
+  value: {{ .Values.mimir.user | quote }}
+{{- end }}
+{{- if .Values.mimir.existingSecret.name }}
+- name: MIMIR_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.mimir.existingSecret.name }}
+      key: {{ .Values.mimir.existingSecret.key }}
+{{- else if .Values.mimir.password }}
+- name: MIMIR_PASSWORD
+  value: {{ .Values.mimir.password | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Resolved name of the Alertmanager config ConfigMap/Secret.
 */}}
 {{- define "mimir-sync.alertmanagerConfigName" -}}

--- a/chart/templates/alertmanager-sync-job.yaml
+++ b/chart/templates/alertmanager-sync-job.yaml
@@ -21,45 +21,23 @@ metadata:
 spec:
   backoffLimit: {{ .Values.alertmanager.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.alertmanager.ttlSecondsAfterFinished }}
+  {{- with .Values.alertmanager.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:
         {{- include "mimir-sync.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: alertmanager-sync
     spec:
-      serviceAccountName: {{ include "mimir-sync.serviceAccountName" . }}
-      restartPolicy: OnFailure
-      {{- with .Values.securityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.alertmanager.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.alertmanager.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.alertmanager.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.alertmanager.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.alertmanager.topologySpreadConstraints }}
-      topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "mimir-sync.podScheduling" (dict "ctx" . "feature" .Values.alertmanager) | nindent 6 }}
       containers:
         - name: alertmanager-sync
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "mimir-sync.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- with .Values.alertmanager.resources }}
           resources:
@@ -76,24 +54,7 @@ spec:
             - --temp.dir={{ .Values.alertmanager.syncTempDir }}
             {{- end }}
           env:
-            - name: MIMIR_ADDRESS
-              value: {{ .Values.mimir.address | quote }}
-            - name: MIMIR_TENANT_ID
-              value: {{ .Values.mimir.tenantId | quote }}
-            {{- if .Values.mimir.user }}
-            - name: MIMIR_USER
-              value: {{ .Values.mimir.user | quote }}
-            {{- end }}
-            {{- if .Values.mimir.existingSecret.name }}
-            - name: MIMIR_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.mimir.existingSecret.name }}
-                  key: {{ .Values.mimir.existingSecret.key }}
-            {{- else if .Values.mimir.password }}
-            - name: MIMIR_PASSWORD
-              value: {{ .Values.mimir.password | quote }}
-            {{- end }}
+            {{- include "mimir-sync.mimirEnv" . | nindent 12 }}
             {{- with .Values.alertmanager.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/chart/templates/loki-rules-sync-job.yaml
+++ b/chart/templates/loki-rules-sync-job.yaml
@@ -22,45 +22,23 @@ metadata:
 spec:
   backoffLimit: {{ .Values.lokiRules.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.lokiRules.ttlSecondsAfterFinished }}
+  {{- with .Values.lokiRules.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:
         {{- include "mimir-sync.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: loki-rules-sync
     spec:
-      serviceAccountName: {{ include "mimir-sync.serviceAccountName" . }}
-      restartPolicy: OnFailure
-      {{- with .Values.securityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.lokiRules.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.lokiRules.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.lokiRules.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.lokiRules.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.lokiRules.topologySpreadConstraints }}
-      topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "mimir-sync.podScheduling" (dict "ctx" . "feature" .Values.lokiRules) | nindent 6 }}
       containers:
         - name: loki-rules-sync
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "mimir-sync.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- with .Values.lokiRules.resources }}
           resources:

--- a/chart/templates/rules-sync-job.yaml
+++ b/chart/templates/rules-sync-job.yaml
@@ -21,45 +21,23 @@ metadata:
 spec:
   backoffLimit: {{ .Values.rules.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.rules.ttlSecondsAfterFinished }}
+  {{- with .Values.rules.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:
         {{- include "mimir-sync.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: rules-sync
     spec:
-      serviceAccountName: {{ include "mimir-sync.serviceAccountName" . }}
-      restartPolicy: OnFailure
-      {{- with .Values.securityContext }}
-      securityContext:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.rules.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.rules.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.rules.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.rules.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.rules.topologySpreadConstraints }}
-      topologySpreadConstraints:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "mimir-sync.podScheduling" (dict "ctx" . "feature" .Values.rules) | nindent 6 }}
       containers:
         - name: rules-sync
           {{- with .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "mimir-sync.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
           {{- with .Values.rules.resources }}
           resources:
@@ -76,24 +54,7 @@ spec:
             - --temp.dir={{ .Values.rules.syncTempDir }}
             {{- end }}
           env:
-            - name: MIMIR_ADDRESS
-              value: {{ .Values.mimir.address | quote }}
-            - name: MIMIR_TENANT_ID
-              value: {{ .Values.mimir.tenantId | quote }}
-            {{- if .Values.mimir.user }}
-            - name: MIMIR_USER
-              value: {{ .Values.mimir.user | quote }}
-            {{- end }}
-            {{- if .Values.mimir.existingSecret.name }}
-            - name: MIMIR_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.mimir.existingSecret.name }}
-                  key: {{ .Values.mimir.existingSecret.key }}
-            {{- else if .Values.mimir.password }}
-            - name: MIMIR_PASSWORD
-              value: {{ .Values.mimir.password | quote }}
-            {{- end }}
+            {{- include "mimir-sync.mimirEnv" . | nindent 12 }}
             {{- with .Values.rules.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -140,6 +140,9 @@ alertmanager:
   backoffLimit: 2
   # -- Job .spec.ttlSecondsAfterFinished (auto-GC of completed jobs).
   ttlSecondsAfterFinished: 3600
+  # -- Job .spec.activeDeadlineSeconds. Caps the wall-clock runtime of a sync attempt
+  # so a hung mimirtool/lokitool (e.g. unreachable backend) cannot run forever. Empty = unset.
+  activeDeadlineSeconds: ""
 
 # Mimir rules sync configuration.
 rules:
@@ -201,6 +204,9 @@ rules:
   backoffLimit: 2
   # -- Job .spec.ttlSecondsAfterFinished.
   ttlSecondsAfterFinished: 3600
+  # -- Job .spec.activeDeadlineSeconds. Caps the wall-clock runtime of a sync attempt
+  # so a hung mimirtool/lokitool (e.g. unreachable backend) cannot run forever. Empty = unset.
+  activeDeadlineSeconds: ""
 
 # Loki rules sync configuration.
 lokiRules:
@@ -249,3 +255,6 @@ lokiRules:
   backoffLimit: 2
   # -- Job .spec.ttlSecondsAfterFinished.
   ttlSecondsAfterFinished: 3600
+  # -- Job .spec.activeDeadlineSeconds. Caps the wall-clock runtime of a sync attempt
+  # so a hung mimirtool/lokitool (e.g. unreachable backend) cannot run forever. Empty = unset.
+  activeDeadlineSeconds: ""


### PR DESCRIPTION
## Summary
Optimization + hardening pass on the chart. The template refactor is **render-identical** (verified by diffing `helm template` output across all features × configmap/secret variants); the only rendered changes are the intended hardening additions.

### Templates (DRY)
- Extract `mimir-sync.podScheduling`, `mimir-sync.mimirEnv`, and `mimir-sync.image` into `_helpers.tpl`. The three sync-Job templates were ~95% identical — the shared scheduling/env/image blocks now live in one place, directly serving the "keep the three feature sets in sync" rule. Net −146/+134 lines.

### Hardening (additive)
- **`automountServiceAccountToken: false`** on all sync pods. The Jobs never call the Kubernetes API (the SA exists only so Reloader can read the config sources), so the token was mounted but unused — unnecessary credential exposure.
- **New per-feature `activeDeadlineSeconds`** knob (default unset). Caps a sync attempt's wall-clock runtime so a hung mimirtool/lokitool (unreachable backend) can't run forever. Complements the `context` timeout added in the `mal-sync` PR (antnsn/mal-sync#7).

### CI
- Extract the triplicated helm-docs install into a **local composite action** (`.github/actions/setup-helm-docs`) used by lint-test, release, and superlinter — one place to bump the pinned version.
- Add **`concurrency: cancel-in-progress`** to the lint-test and superlinter PR workflows so superseded runs are cancelled.

### Validation
- `helm template` diff vs baseline: only `automountServiceAccountToken: false` added per job ✓
- `activeDeadlineSeconds` renders only when set ✓
- `helm lint` ✓, both `helm template` passes ✓, helm-docs no residual drift ✓
- `/codex:review` clean

Chart version `3.0.3` → `3.1.0` (additive). `appVersion` unchanged (no image contract change).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>